### PR TITLE
cmake: Enable standard warnings.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.6.0)
 
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Woverloaded-virtual -Wshadow -Wextra")
+
 # Use your own vmelib
 add_library(vmelib vmelib/vmelib.cpp vmelib/include/vmelib.h) 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.6.0)
+PROJECT(JDAQLITE)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Woverloaded-virtual -Wshadow -Wextra")
 
@@ -8,6 +9,4 @@ add_library(vmelib vmelib/vmelib.cpp vmelib/include/vmelib.h)
 add_executable(jDAQLite jDAQLite.cpp)
 target_link_libraries(jDAQLite vmelib)
 
-
- 
-
+INSTALL(TARGETS jDAQLite DESTINATION bin)


### PR DESCRIPTION
Only those flags which all standard compilers support.
