### PR TITLE
travis: Add automatic build checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+before_install:
+  # g++ 4.8 on linux
+  - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+
+  # clang 3.4 - already with travis
+  #- if [ "$CXX" == "clang++" ]; then sudo add-apt-repository -y ppa:h-rayflood/llvm; fi
+
+  - sudo apt-get update -qq
+
+install:
+  # g++ 4.8 on linux
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
+
+  # clang 3.4 - already with travis
+  #- if [ "$CXX" == "clang++" ]; then sudo apt-get install --allow-unauthenticated -qq clang-3.4; fi
+  #- if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
+
+before_script:
+  - mkdir -p ${TRAVIS_BUILD_DIR}/build
+  - mkdir -p ${TRAVIS_BUILD_DIR}/install
+  - cd ${TRAVIS_BUILD_DIR}/build
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH=${TRAVIS_BUILD_DIR}/install ../src/
+
+env:
+  - PATH=${PATH}:${TRAVIS_BUILD_DIR}/install/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${TRAVIS_BUILD_DIR}/install/lib
+
+script:
+  - env
+  - make
+# - make install
+# - cd ${TRAVIS_BUILD_DIR}/install
+# - jDAQLite


### PR DESCRIPTION
Compiles with modern gcc and clang.
Does not yet install nor executes jDAQLite without parameters,
to be done after cmake-changes.

PS: Happy Birthday ;-)

PPS: To make this work, you need a free github-linked account at travis-ci and add the repo from here - then you can also get automatic mails on build or execute failure, and will get automatic tests for each pull request :-). 
